### PR TITLE
feat!: Add a new view to display assigned stories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add a new tree view for assigned stories [#5](https://github.com/anirvanmandal/vscode-shortcut/issues/5)
+
 ### Changed
 
-- Create a new view container in the activity bar and move the existing tree view to it [#1](https://github.com/anirvanmandal/vscode-shortcut/issues/1)
 - Cache the workspaces and member info to reduce API calls. Add an action to delete the cache and refresh the workspaces. [#4](https://github.com/anirvanmandal/vscode-shortcut/issues/4)
+- Create a new view container in the activity bar and move the existing tree view to it [#1](https://github.com/anirvanmandal/vscode-shortcut/issues/1)
+
 
 ## [0.0.2] - 2025-01-25
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "main": "./dist/extension.js",
   "contributes": {
     "configuration": [{
-      "title": "Shortcut Tasks",
+      "title": "Shortcut",
       "properties": {
-        "shortcutTasks.apiTokens": {
+        "shortcut.apiTokens": {
           "title": "API Tokens",
           "markdownDescription": "The list of workspace and their API tokens",
           "type": "object",
@@ -56,6 +56,11 @@
         "command": "refreshWorkspaces",
         "title": "Shortcut: Refresh Workspaces",
         "icon": "$(extensions-refresh)"
+      },
+      {
+        "command": "copyBranchName",
+        "title": "Shortcut: Copy Branch Name",
+        "icon": "$(copy)"
       }
     ],
     "viewsContainers": {
@@ -66,10 +71,16 @@
       }]
     },
     "views": {
-      "shortcut": [{
-        "id": "pendingTasks",
-        "name": "Pending Tasks"
-      }]
+      "shortcut": [
+        {
+          "id": "pendingTasks",
+          "name": "Pending Tasks"
+        },
+        {
+          "id": "assignedStories",
+          "name": "Assigned Stories"
+        }
+      ]
     },
     "menus": {
       "view/title": [
@@ -82,12 +93,17 @@
       "view/item/context": [
         {
           "command": "pendingTasks.openStory", 
-          "when": "view == pendingTasks && viewItem == story",
+          "when": "(view == pendingTasks && viewItem == story) || (view == assignedStories && viewItem == story)",
           "group": "inline"
         },
         {
           "command": "pendingTasks.completeTask",
           "when": "view == pendingTasks && viewItem == task && !viewItem.isComplete",
+          "group": "inline"
+        },
+        {
+          "command": "copyBranchName",
+          "when": "view == assignedStories && viewItem == story",
           "group": "inline"
         }
       ]
@@ -95,6 +111,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
+    "publish": "npm run package && vsce publish",
     "compile": "npm run check-types && npm run lint && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",

--- a/src/assignedStoryTreeProvider.ts
+++ b/src/assignedStoryTreeProvider.ts
@@ -1,0 +1,134 @@
+import * as vscode from 'vscode';
+import { Story } from './models/story';
+import { Workspace } from './models/workspace';
+import { Workflow } from './models/workflow';
+import { WorkflowState } from './models/workflowState';
+import removeMarkdown from "markdown-to-text";
+
+export class AssignedStoryTreeProvider implements vscode.TreeDataProvider<TreeItem> {
+    private _onDidChangeTreeData: vscode.EventEmitter<TreeItem | undefined | null | void> = new vscode.EventEmitter<TreeItem | undefined | null | void>();
+    readonly onDidChangeTreeData: vscode.Event<TreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
+
+    private workspaces: Workspace[] = [];
+
+    constructor() {}
+
+    refresh(workspaces: Workspace[]): void {
+        this.workspaces = workspaces;
+        this._onDidChangeTreeData.fire();
+    }
+
+    getTreeItem(element: TreeItem): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(element?: TreeItem): Thenable<TreeItem[]> {
+        if (!element) {
+            return Promise.resolve(
+                this.workspaces.map(workspace => new WorkspaceTreeItem(
+                    workspace.name,
+                    workspace.workflows.length > 0 ? 
+                        vscode.TreeItemCollapsibleState.Collapsed :
+                        vscode.TreeItemCollapsibleState.None,
+                    workspace
+                ))
+            );
+        } else if (element instanceof WorkspaceTreeItem) {
+            return Promise.resolve(
+                element.workspace.workflows.map(workflow => new WorkflowTreeItem(
+                    `${workflow.name} (${workflow.states.map(state => state.stories.length).reduce((a, b) => a + b, 0)})`,
+                    workflow.id.toString(),
+                    workflow.states.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
+                    workflow,
+                    element.workspace,
+                ))
+            );
+        } else if (element instanceof WorkflowTreeItem) {
+            return Promise.resolve(
+                element.workflow.states.map(state => new StateTreeItem(
+                    `${state.name} (${state.stories.length})`,
+                    state.id.toString(),
+                    state,
+                    state.stories.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
+                    element.workspace
+                ))
+            );
+        } else if (element instanceof StateTreeItem) {
+            return Promise.resolve(
+                element.state.stories.map(story => new StoryTreeItem(
+                    story.name,
+                    story.id.toString(),
+                        vscode.TreeItemCollapsibleState.None,
+                    story,
+                    element.workspace
+                ))
+            );
+        } else {
+            return Promise.resolve([]);
+        }
+    }
+}
+
+
+class TreeItem extends vscode.TreeItem {
+    constructor(
+        public readonly label: string,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState
+    ) {
+        super(label, collapsibleState);
+    }
+}
+
+class WorkspaceTreeItem extends TreeItem {
+    constructor(
+        public readonly label: string,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly workspace: Workspace
+    ) {
+        super(label, collapsibleState);
+    }
+}
+
+class WorkflowTreeItem extends TreeItem {
+    constructor(
+        public readonly label: string,
+        public readonly id: string,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly workflow: Workflow,
+        public readonly workspace: Workspace
+    ) {
+        super(label, collapsibleState);
+        this.workspace = workspace;
+    }
+}
+
+class StateTreeItem extends TreeItem {
+    constructor(
+        public readonly label: string,
+        public readonly id: string,
+        public readonly state: WorkflowState,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly workspace: Workspace
+    ) {
+        super(label, collapsibleState);
+        this.workspace = workspace;
+    }
+}
+
+class StoryTreeItem extends TreeItem {
+    constructor(
+        public readonly label: string,
+        public readonly storyId: string,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly story: Story,
+        public readonly workspace: Workspace
+    ) {
+        super(label, collapsibleState);
+        this.tooltip = `${this.label}`;
+        this.description = `#${this.storyId}`;
+        this.contextValue = 'story';
+        this.story = story;
+        this.workspace = workspace;
+        this.iconPath = new vscode.ThemeIcon('book');
+    }
+}

--- a/src/lib/loadAssignedStories.ts
+++ b/src/lib/loadAssignedStories.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode';
+import { Workspace } from '../models/workspace';
+import { AssignedStoryTreeProvider } from '../assignedStoryTreeProvider';
+
+export const loadAssignedStories = async (workspaces: Workspace[], treeProvider: AssignedStoryTreeProvider) => {
+    try {
+		await vscode.window.withProgress({
+			location: vscode.ProgressLocation.Notification,
+			title: "Fetching Workflow States...",
+			cancellable: false
+		}, async (progress) => {
+            for (const workspace of workspaces) { 
+                await workspace.getAssignedStories();
+                treeProvider.refresh(workspaces);
+            }
+            
+			if (workspaces.length === 0) {
+				vscode.window.showInformationMessage('No workspaces found in Shortcut.');
+			}
+		});
+	} catch (error: any) {
+		vscode.window.showErrorMessage(`Error fetching Assigns Stories: ${error.message}`);
+	}
+};

--- a/src/lib/loadPendingTasks.ts
+++ b/src/lib/loadPendingTasks.ts
@@ -2,18 +2,18 @@ import * as vscode from 'vscode';
 import { Workspace } from '../models/workspace';
 import { StoryTreeProvider } from '../storyTreeProvider';
 
-export const loadWorkspaces = async (workspaces: Workspace[], storyTreeProvider: StoryTreeProvider) => {
+export const loadPendingTasks = async (workspaces: Workspace[], storyTreeProvider: StoryTreeProvider) => {
     try {
 		await vscode.window.withProgress({
 			location: vscode.ProgressLocation.Notification,
 			title: "Fetching Pending tasks...",
 			cancellable: false
 		}, async (progress) => {
-				for (const workspace of workspaces) {
-					await workspace.getStories();
-					storyTreeProvider.refresh(workspaces);
-				}
-
+			for (const workspace of workspaces) {
+				await workspace.getPendingStories();
+				storyTreeProvider.refresh(workspaces);
+			}
+			
 			if (workspaces.length === 0) {
 				vscode.window.showInformationMessage('No workspaces found in Shortcut.');
 			}
@@ -21,4 +21,4 @@ export const loadWorkspaces = async (workspaces: Workspace[], storyTreeProvider:
 	} catch (error: any) {
 		vscode.window.showErrorMessage(`Error fetching Pending tasks: ${error.message}`);
 	}
-};
+``};

--- a/src/lib/markTaskAsComplete.ts
+++ b/src/lib/markTaskAsComplete.ts
@@ -9,7 +9,7 @@ export const markTaskAsComplete = async (workspace: Workspace, taskId: number, s
 
     if (response.status === 200) {
         vscode.window.showInformationMessage('Task marked as complete');
-        const story = workspace.stories.find(story => story.id === storyId);
+        const story = workspace.pendingStories.find(story => story.id === storyId);
         const task = story?.tasks.find(task => task.id === taskId);
         if (story && task) {
             task.complete = true;

--- a/src/models/memberInfo.ts
+++ b/src/models/memberInfo.ts
@@ -5,7 +5,6 @@ export class MemberInfo extends BaseModel {
     id: string;
     name: string;
     mention_name: string;
-    workspace: Workspace | undefined;
 
     constructor(id?: string, name?: string, mentionName?: string) {
         super();
@@ -21,7 +20,6 @@ export class MemberInfo extends BaseModel {
     static async fetch(workspace: Workspace): Promise<MemberInfo> {
         const response = await workspace.client.getCurrentMemberInfo();
         const memberInfo = MemberInfo.fromJson(response.data);
-        memberInfo.workspace = workspace;
         workspace.updateAttributes(response.data, memberInfo);
         
         return memberInfo;
@@ -56,7 +54,6 @@ export class MemberInfo extends BaseModel {
         let memberInfo = MemberInfo.fetchFromCache(workspace.name);
         
         if (memberInfo) {
-            memberInfo.workspace = workspace;
             console.log("loaded from cache");
             return memberInfo;
         }

--- a/src/models/story.ts
+++ b/src/models/story.ts
@@ -8,6 +8,8 @@ export class Story extends BaseModel {
     app_url: string;
     name: string;
     tasks: Task[];
+    workflow_id: number;
+    workflow_state_id: number;
     
     constructor(story: ShortcutStory | any) {
         super();
@@ -15,6 +17,8 @@ export class Story extends BaseModel {
         this.name = story.name ?? "";
         this.app_url = story.app_url ?? "";
         this.tasks = story.tasks.map((task: ShortcutTask) => new Task(task));
+        this.workflow_id = story.workflow_id ?? 0;
+        this.workflow_state_id = story.workflow_state_id ?? 0;
     }
 
     static async all(): Promise<Story[]> {
@@ -31,6 +35,26 @@ export class Story extends BaseModel {
             return [];
         }
         return all_stories.filter(story => story.tasks.some(task => task.member_mention_ids.includes(member.id) && !task.complete));
+    }
+
+    static async assignedToMember(workspace: Workspace): Promise<Story[]> {
+        let response = await workspace.client.searchStories({ query: `!is:done and !is:archived and owner:${workspace.memberInfo?.mention_name}`, page_size: 25, detail: "full" });
+        let stories = Story.parseStorySearchResults(response.data);
+
+        while (response.data.next !== null) {
+            response = await workspace.client.searchStories({ query: `!is:done and !is:archived and owner:${workspace.memberInfo?.mention_name}`, page_size: 25, detail: "full", next: response.data.next });
+            stories = stories.concat(Story.parseStorySearchResults(response.data));
+        }
+
+        return stories;
+    }
+
+    storyIdentifier(): string {
+        return this.app_url.split('/').pop()?.split('-').slice(0, 6).join('-') ?? '';
+    }
+
+    branchName(workspace: Workspace): string {
+        return `${workspace.memberInfo?.mention_name}/sc-${this.id}/${this.storyIdentifier()}`;
     }
 
     static parseStorySearchResults(results: StorySearchResults): Story[] {

--- a/src/models/workflow.ts
+++ b/src/models/workflow.ts
@@ -1,0 +1,71 @@
+import { BaseModel } from "./base";
+import { Workspace } from "./workspace";
+import { WorkflowState } from "./workflowState";
+
+export class Workflow extends BaseModel {
+    id: number;
+    name: string;
+    states: WorkflowState[];
+
+    constructor(id?: number, name?: string, states?: WorkflowState[]) {
+        super();
+        this.id = id ?? 0;
+        this.name = name ?? "";
+        this.states = states ?? [];
+    }
+
+    static fromJson(json: any): Workflow[] {
+        return json.map((jsonWorkflow: any) => new Workflow(jsonWorkflow.id, jsonWorkflow.name, jsonWorkflow.states.map((jsonState: any) => new WorkflowState(jsonState.id, jsonState.name))));
+    }
+
+    static async fetch(workspace: Workspace): Promise<Workflow[]> {
+        const response = await workspace.client.listWorkflows();
+        const workflows = Workflow.fromJson(response.data);
+
+        return workflows;
+    }
+
+    static fetchFromCache(workspaceName: string): Workflow[] | null {
+        const cacheKey = Workflow.cacheKey(workspaceName);
+        const cache = BaseModel.context.globalState.get(cacheKey);
+        if (cache) {
+            return Workflow.fromJson(JSON.parse(cache));
+        }
+        return null;
+    }
+
+    static async saveToCache(workspaceName: string, workflows: Workflow[]) {
+        Workflow.context.globalState.update(Workflow.cacheKey(workspaceName), JSON.stringify(workflows.map(workflow => workflow.toObject())));
+    }
+
+    toObject(): object {
+        return {
+            id: this.id,
+            name: this.name,
+            states: this.states.map(state => state.toObject())
+        };
+    }
+
+    static cacheKey(workspaceName: string): string {
+        return `${workspaceName}-workflows`;
+    }
+
+    static async get(workspace: Workspace): Promise<Workflow[]> {
+        let workflows = Workflow.fetchFromCache(workspace.name);
+        
+        if (workflows) {
+            console.log("loaded from cache");
+            return workflows;
+        }
+        
+        workflows = await Workflow.fetch(workspace);
+        Workflow.saveToCache(workspace.name, workflows);
+
+        return workflows;
+    }
+
+    static deleteCache(workspaceName: string) {
+        const cacheKey = Workflow.cacheKey(workspaceName);
+        Workflow.context.globalState.update(cacheKey, undefined);
+    }
+}

--- a/src/models/workflowState.ts
+++ b/src/models/workflowState.ts
@@ -1,0 +1,26 @@
+import { BaseModel } from "./base";
+import { Story } from "./story";
+
+export class WorkflowState extends BaseModel {
+    id: number;
+    name: string;
+    stories: Story[];
+
+    constructor(id?: number, name?: string, stories?: Story[]) {
+        super();
+        this.id = id ?? 0;
+        this.name = name ?? "";
+        this.stories = stories ?? [];
+    }
+
+    static fromJson(json: any): WorkflowState[] {
+        return json.map((jsonWorkflow: any) => new WorkflowState(jsonWorkflow.id, jsonWorkflow.name));
+    }
+
+    toObject(): object {
+        return {
+            id: this.id,
+            name: this.name
+        };
+    }
+}

--- a/src/storyTreeProvider.ts
+++ b/src/storyTreeProvider.ts
@@ -25,9 +25,9 @@ export class StoryTreeProvider implements vscode.TreeDataProvider<TreeItem> {
             // Root level - return stories
             return Promise.resolve(
                 this.workspaces.map(workspace => new WorkspaceTreeItem(
-                    workspace.name,
-                    workspace.stories.length > 0 ? 
-                        vscode.TreeItemCollapsibleState.Expanded : 
+                    `${workspace.name} (${workspace.pendingStories.length})`,
+                    workspace.pendingStories.length > 0 ? 
+                        vscode.TreeItemCollapsibleState.Collapsed : 
                         vscode.TreeItemCollapsibleState.None,
                     workspace
                 ))
@@ -35,11 +35,11 @@ export class StoryTreeProvider implements vscode.TreeDataProvider<TreeItem> {
         } else if (element instanceof WorkspaceTreeItem) {
             // Story level - return tasks
             return Promise.resolve(
-                element.workspace.stories.map(story => new StoryTreeItem(
+                element.workspace.pendingStories.map(story => new StoryTreeItem(
                     story.name,
                     story.id,
                     story.tasks.length > 0 ? 
-                        vscode.TreeItemCollapsibleState.Expanded : 
+                        vscode.TreeItemCollapsibleState.Collapsed : 
                         vscode.TreeItemCollapsibleState.None,
                     story,
                     element.workspace


### PR DESCRIPTION
Closes #5 

- Add a new view to display assigned stories
- Add a new tree view provider
- Add a new action to generate github helper for story
- Refactor naming