### PR TITLE
feat: Add a new setting to hide empty workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,15 @@
             }
           }
         }
+      }, {
+        "title": "Shortcut",
+        "properties": {
+          "shortcut.hideEmptyWorkspaces": {
+            "description": "Hide workspaces with no pending tasks or assigned stories",
+            "type": "boolean",
+            "default": false
+          }
+        }
       }
     ],
     "commands": [

--- a/src/assignedStoryTreeProvider.ts
+++ b/src/assignedStoryTreeProvider.ts
@@ -3,11 +3,16 @@ import { Story } from './models/story';
 import { Workspace } from './models/workspace';
 import { Workflow } from './models/workflow';
 import { WorkflowState } from './models/workflowState';
+import { Config } from './models/config';
 
 /**
  * Tree data provider for displaying assigned Shortcut stories organized by workflow state.
  * Implements the VS Code TreeDataProvider interface to create a hierarchical view of:
  * Workspace -> Workflow -> State -> Stories
+ * 
+ * The tree shows stories assigned to the current user, grouped by their workflow state.
+ * Each level displays the number of stories contained within it in parentheses.
+ * Empty workspaces, workflows and states can be optionally hidden via configuration.
  */
 export class AssignedStoryTreeProvider implements vscode.TreeDataProvider<TreeItem> {
     /** Event emitter for notifying VS Code when the tree data changes */
@@ -17,20 +22,28 @@ export class AssignedStoryTreeProvider implements vscode.TreeDataProvider<TreeIt
 
     /** Array of workspaces containing workflows, states and stories */
     private workspaces: Workspace[] = [];
+    /** Configuration settings for the tree view */
+    private config: Config = new Config();
 
     constructor() {}
 
     /**
-     * Refreshes the tree view with updated workspace data.
+     * Refreshes the tree view with updated workspace data and configuration.
+     * Triggers a re-render of the entire tree.
+     * 
      * @param {Workspace[]} workspaces - Array of workspaces to display
+     * @param {Config} config - Updated configuration settings
      */
-    refresh(workspaces: Workspace[]): void {
+    refresh(workspaces: Workspace[], config: Config): void {
         this.workspaces = workspaces;
+        this.config = config;
         this._onDidChangeTreeData.fire();
     }
 
     /**
      * Gets the tree item for an element.
+     * Required by VS Code's TreeDataProvider interface.
+     * 
      * @param {TreeItem} element - The element to get the tree item for
      * @returns {vscode.TreeItem} The tree item for the element
      */
@@ -40,40 +53,70 @@ export class AssignedStoryTreeProvider implements vscode.TreeDataProvider<TreeIt
 
     /**
      * Gets the children of a tree item.
+     * Handles the hierarchical structure of the tree:
+     * - Root level shows workspaces
+     * - Workspaces contain workflows
+     * - Workflows contain states
+     * - States contain stories
+     * 
+     * Each level can filter out empty items based on configuration.
+     * Story counts are calculated and displayed at each level.
+     * 
      * @param {TreeItem} [element] - The parent element to get children for
      * @returns {Thenable<TreeItem[]>} Promise resolving to array of child tree items
      */
     getChildren(element?: TreeItem): Thenable<TreeItem[]> {
         if (!element) {
-            return Promise.resolve(
-                this.workspaces.map(workspace => new WorkspaceTreeItem(
-                    workspace.name,
+            let displayedWorkspaces = this.workspaces.map(workspace => {
+                const workspaceStoriesCount = workspace.workflows.map(workflow => workflow.states.map(state => state.stories.length).reduce((a,b) => a + b, 0)).reduce((a,b) => a + b, 0);
+                let workspaceTreeItem = new WorkspaceTreeItem(
+                    `${workspace.name} (${workspaceStoriesCount})`,
                     workspace.workflows.length > 0 ? 
                         vscode.TreeItemCollapsibleState.Collapsed :
                         vscode.TreeItemCollapsibleState.None,
-                    workspace
-                ))
-            );
+                    workspace,
+                    workspaceStoriesCount
+                );
+                return workspaceTreeItem;
+            });
+
+            if (this.config.hideEmptyWorkspaces) {
+                displayedWorkspaces = displayedWorkspaces.filter(workspace => workspace.storiesCount > 0);
+            }
+
+            return Promise.resolve(displayedWorkspaces);
         } else if (element instanceof WorkspaceTreeItem) {
-            return Promise.resolve(
-                element.workspace.workflows.map(workflow => new WorkflowTreeItem(
-                    `${workflow.name} (${workflow.states.map(state => state.stories.length).reduce((a, b) => a + b, 0)})`,
+            let displayedWorkflows = element.workspace.workflows.map(workflow => {
+                const workflowStoriesCount = workflow.states.map(state => state.stories.length).reduce((a, b) => a + b, 0);
+                let workflowTreeItem = new WorkflowTreeItem(
+                    `${workflow.name} (${workflowStoriesCount})`,
                     workflow.id.toString(),
                     workflow.states.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
                     workflow,
                     element.workspace,
-                ))
-            );
+                    workflowStoriesCount
+                );
+                return workflowTreeItem;
+            });
+
+            displayedWorkflows = displayedWorkflows.filter(workflow => workflow.storiesCount > 0);
+            
+            return Promise.resolve(displayedWorkflows);
         } else if (element instanceof WorkflowTreeItem) {
-            return Promise.resolve(
-                element.workflow.states.map(state => new StateTreeItem(
-                    `${state.name} (${state.stories.length})`,
+            let displayedStates = element.workflow.states.map(state => {
+                const stateStoriesCount = state.stories.length;
+                let stateTreeItem = new StateTreeItem(
+                    `${state.name} (${stateStoriesCount})`,
                     state.id.toString(),
                     state,
-                    state.stories.length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
-                    element.workspace
-                ))
-            );
+                    stateStoriesCount > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
+                    element.workspace,
+                    stateStoriesCount
+                );
+                return stateTreeItem;
+            });
+            displayedStates = displayedStates.filter(state => state.storiesCount > 0);
+            return Promise.resolve(displayedStates);
         } else if (element instanceof StateTreeItem) {
             return Promise.resolve(
                 element.state.stories.map(story => new StoryTreeItem(
@@ -92,11 +135,14 @@ export class AssignedStoryTreeProvider implements vscode.TreeDataProvider<TreeIt
 
 /**
  * Base tree item class that all other tree items extend from.
+ * Provides common functionality for tree items in the view.
+ * 
  * @extends vscode.TreeItem
  */
 class TreeItem extends vscode.TreeItem {
     /**
      * Creates a new TreeItem instance.
+     * 
      * @param {string} label - The display text for the tree item
      * @param {vscode.TreeItemCollapsibleState} collapsibleState - Whether and how the tree item can be expanded
      */
@@ -110,19 +156,25 @@ class TreeItem extends vscode.TreeItem {
 
 /**
  * Tree item representing a Shortcut workspace.
+ * The top level of the hierarchy that contains workflows.
+ * Displays the total number of stories in the workspace.
+ * 
  * @extends TreeItem
  */
 class WorkspaceTreeItem extends TreeItem {
     /**
      * Creates a new WorkspaceTreeItem instance.
+     * 
      * @param {string} label - The display text for the workspace
      * @param {vscode.TreeItemCollapsibleState} collapsibleState - Whether and how the workspace can be expanded
      * @param {Workspace} workspace - The workspace this tree item represents
+     * @param {number} storiesCount - Total number of stories in this workspace
      */
     constructor(
         public readonly label: string,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-        public readonly workspace: Workspace
+        public readonly workspace: Workspace,
+        public readonly storiesCount: number
     ) {
         super(label, collapsibleState);
     }
@@ -130,61 +182,76 @@ class WorkspaceTreeItem extends TreeItem {
 
 /**
  * Tree item representing a Shortcut workflow.
+ * The second level of the hierarchy that contains states.
+ * Displays the total number of stories in the workflow.
+ * 
  * @extends TreeItem
  */
 class WorkflowTreeItem extends TreeItem {
     /**
      * Creates a new WorkflowTreeItem instance.
+     * 
      * @param {string} label - The display text for the workflow
      * @param {string} id - The unique identifier of the workflow
      * @param {vscode.TreeItemCollapsibleState} collapsibleState - Whether and how the workflow can be expanded
      * @param {Workflow} workflow - The workflow this tree item represents
      * @param {Workspace} workspace - The workspace containing this workflow
+     * @param {number} storiesCount - Total number of stories in this workflow
      */
     constructor(
         public readonly label: string,
         public readonly id: string,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
         public readonly workflow: Workflow,
-        public readonly workspace: Workspace
+        public readonly workspace: Workspace,
+        public readonly storiesCount: number
     ) {
         super(label, collapsibleState);
-        this.workspace = workspace;
     }
 }
 
 /**
  * Tree item representing a workflow state in Shortcut.
+ * The third level of the hierarchy that contains stories.
+ * Displays the number of stories in this state.
+ * 
  * @extends TreeItem
  */
 class StateTreeItem extends TreeItem {
     /**
      * Creates a new StateTreeItem instance.
+     * 
      * @param {string} label - The display text for the state
      * @param {string} id - The unique identifier of the state
      * @param {WorkflowState} state - The workflow state this tree item represents
      * @param {vscode.TreeItemCollapsibleState} collapsibleState - Whether and how the state can be expanded
      * @param {Workspace} workspace - The workspace containing this state
+     * @param {number} storiesCount - Number of stories in this state
      */
     constructor(
         public readonly label: string,
         public readonly id: string,
         public readonly state: WorkflowState,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-        public readonly workspace: Workspace
+        public readonly workspace: Workspace,
+        public readonly storiesCount: number
     ) {
         super(label, collapsibleState);
-        this.workspace = workspace;
     }
 }
 
 /**
  * Tree item representing a Shortcut story.
+ * The leaf level of the hierarchy.
+ * Displays the story name and ID, with a book icon.
+ * Provides context menu actions via contextValue.
+ * 
  * @extends TreeItem
  */
 class StoryTreeItem extends TreeItem {
     /**
      * Creates a new StoryTreeItem instance.
+     * 
      * @param {string} label - The display text for the story
      * @param {string} storyId - The unique identifier of the story
      * @param {vscode.TreeItemCollapsibleState} collapsibleState - Whether and how the story can be expanded

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,30 +9,37 @@ import { Workspace } from './models/workspace';
 import { loadPendingTasks } from './lib/loadPendingTasks';
 import { loadAssignedStories } from './lib/loadAssignedStories';
 import { markTaskAsComplete } from './lib/markTaskAsComplete';
+import { Config } from './models/config';
 
 /**
  * Retrieves the Shortcut extension configuration from VS Code settings.
- * @returns {vscode.WorkspaceConfiguration} The extension's configuration
+ * @returns {vscode.WorkspaceConfiguration} The extension's configuration settings
  */
 function getConfiguration(): vscode.WorkspaceConfiguration {
 	return vscode.workspace.getConfiguration('shortcut');
 }
 
-let apiTokens: object | undefined;
+let config: Config;
 
 /**
  * Activates the extension and sets up all necessary components.
- * This includes:
- * - Setting up tree views for pending tasks and assigned stories
- * - Initializing workspaces with API tokens
- * - Registering commands for task management
- * - Setting up configuration change listeners
  * 
- * @param {vscode.ExtensionContext} context - The VS Code extension context
+ * Sets up:
+ * - Tree views for pending tasks and assigned stories
+ * - Initializes workspaces with API tokens from configuration
+ * - Registers commands for:
+ *   - Fetching pending tasks and assigned stories
+ *   - Completing tasks
+ *   - Copying branch names
+ *   - Opening stories in browser
+ *   - Refreshing workspaces
+ * - Listens for configuration changes to update workspaces and views
+ * 
+ * @param {vscode.ExtensionContext} context - The VS Code extension context providing access to extension utilities and resources
  * @returns {Promise<void>} A promise that resolves when activation is complete
  */
 export async function activate(context: vscode.ExtensionContext) {
-	updateFromConfig(getConfiguration());
+	updateConfig(getConfiguration());
 	BaseModel.context = context;
 	let workspaces: Workspace[] = [];
 
@@ -49,46 +56,48 @@ export async function activate(context: vscode.ExtensionContext) {
 		treeDataProvider: assignedStoryTreeProvider
 	});
 	
-	storyTreeProvider.refresh([]);
-	assignedStoryTreeProvider.refresh([]);
+	storyTreeProvider.refresh([], config);
+	assignedStoryTreeProvider.refresh([], config);
 
 	context.subscriptions.push(treeView);
 	context.subscriptions.push(assignedTreeView);
 
-	workspaces = await Workspace.get(apiTokens);
+	workspaces = await Workspace.get(config.apiTokens);
 
-	storyTreeProvider.refresh(workspaces);
-	assignedStoryTreeProvider.refresh(workspaces);
-	loadPendingTasks(workspaces, storyTreeProvider);
-	loadAssignedStories(workspaces, assignedStoryTreeProvider);
+	storyTreeProvider.refresh(workspaces, config);
+	assignedStoryTreeProvider.refresh(workspaces, config);
+	loadPendingTasks(workspaces, storyTreeProvider, config);
+	loadAssignedStories(workspaces, assignedStoryTreeProvider, config);
 
-	// Register command to fetch tasks
+	// Register command to fetch pending tasks
 	let pendingTasksDisposable = vscode.commands.registerCommand('shortcut.pendingTasks.fetchStories', async () => {
-		loadPendingTasks(workspaces, storyTreeProvider);
+		loadPendingTasks(workspaces, storyTreeProvider, config);
 	});
 
+	// Register command to fetch assigned stories
 	let assignedStoriesDisposable = vscode.commands.registerCommand('shortcut.assignedStories.fetchStories', async () => {
-		loadAssignedStories(workspaces, assignedStoryTreeProvider);
+		loadAssignedStories(workspaces, assignedStoryTreeProvider, config);
 	});
 
-	// Listen for configuration changes
+	// Listen for configuration changes and update workspaces/views
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration(async e => {
 			if (e.affectsConfiguration('shortcut')) {
-				const config = getConfiguration();
-				updateFromConfig(config);
+				updateConfig(getConfiguration());
 				Workspace.deleteCache(workspaces);
-				workspaces = await Workspace.get(apiTokens);
-				loadPendingTasks(workspaces, storyTreeProvider);
-				loadAssignedStories(workspaces, assignedStoryTreeProvider);
+				workspaces = await Workspace.get(config.apiTokens);
+				loadPendingTasks(workspaces, storyTreeProvider, config);
+				loadAssignedStories(workspaces, assignedStoryTreeProvider, config);
 			}
 		})
 	);
 
+	// Register command to mark a task as complete
 	context.subscriptions.push(vscode.commands.registerCommand('shortcut.pendingTasks.completeTask', async (item: any) => {
 		markTaskAsComplete(item.workspace, item.taskId, item.storyId);
 	}));
 
+	// Register command to copy story branch name
 	context.subscriptions.push(vscode.commands.registerCommand('shortcut.copyBranchName', async (item: any) => {
 		vscode.env.clipboard.writeText(item.story.branchName(item.workspace));
 	}));
@@ -96,28 +105,32 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(pendingTasksDisposable);
 	context.subscriptions.push(assignedStoriesDisposable);
 	
+	// Register command to open story in browser
 	context.subscriptions.push(vscode.commands.registerCommand('shortcut.openStory', async (item: any) => {
 		vscode.env.openExternal(vscode.Uri.parse(item.story.app_url));
 	}));
 
+	// Register command to refresh workspaces and views
 	context.subscriptions.push(vscode.commands.registerCommand('shortcut.refreshWorkspaces', async () => {
 		Workspace.deleteCache(workspaces);
-		workspaces = await Workspace.get(apiTokens);
-		loadPendingTasks(workspaces, storyTreeProvider);
-		loadAssignedStories(workspaces, assignedStoryTreeProvider);
+		workspaces = await Workspace.get(config.apiTokens);
+		loadPendingTasks(workspaces, storyTreeProvider, config);
+		loadAssignedStories(workspaces, assignedStoryTreeProvider, config);
 	}));
 }
 
 /**
- * Updates the extension's configuration from VS Code settings.
- * @param {vscode.WorkspaceConfiguration} config - The new configuration
+ * Updates the extension's configuration settings.
+ * Creates a new Config instance with the provided VS Code workspace configuration.
+ * 
+ * @param {vscode.WorkspaceConfiguration} vscodeConfig - The VS Code workspace configuration for the extension
  */
-function updateFromConfig(config: vscode.WorkspaceConfiguration) {
-	apiTokens = config.get<object[]>('apiTokens');
+function updateConfig(vscodeConfig: vscode.WorkspaceConfiguration) {
+	config = new Config(vscodeConfig);
 }
 
 /**
  * Handles cleanup when the extension is deactivated.
- * Currently no cleanup is needed.
+ * Currently no cleanup is needed, but this function is required by VS Code's extension API.
  */
 export function deactivate() {}

--- a/src/lib/loadAssignedStories.ts
+++ b/src/lib/loadAssignedStories.ts
@@ -1,26 +1,35 @@
 import * as vscode from 'vscode';
 import { Workspace } from '../models/workspace';
 import { AssignedStoryTreeProvider } from '../assignedStoryTreeProvider';
+import { Config } from '../models/config';
 
 /**
  * Loads stories assigned to the current user for all workspaces and updates the tree view.
  * Shows a progress notification while fetching stories and handles any errors.
  * 
+ * For each workspace, it:
+ * 1. Fetches assigned stories via the Shortcut API
+ * 2. Updates the tree view to reflect the new stories
+ * 3. Shows a notification if no workspaces are found
+ * 
  * @param {Workspace[]} workspaces - Array of workspaces to fetch assigned stories for
  * @param {AssignedStoryTreeProvider} treeProvider - Provider for the assigned stories tree view
+ * @param {Config} config - Configuration settings for the extension
  * @returns {Promise<void>} A promise that resolves when all stories are loaded
- * @throws {Error} If there's an error fetching assigned stories
+ * @throws {Error} If there's an error fetching assigned stories from the API
  */
-export const loadAssignedStories = async (workspaces: Workspace[], treeProvider: AssignedStoryTreeProvider) => {
+export const loadAssignedStories = async (workspaces: Workspace[], treeProvider: AssignedStoryTreeProvider, config: Config) => {
     try {
 		await vscode.window.withProgress({
 			location: vscode.ProgressLocation.Notification,
-			title: "Fetching Assigned Stories...",
+			title: "Fetching Assigned Stories. Workspace: ",
 			cancellable: false
 		}, async (progress) => {
             for (const workspace of workspaces) { 
+				progress.report({message: `${workspace.name}` });
                 await workspace.getAssignedStories();
-                treeProvider.refresh(workspaces);
+				progress.report({ increment: ((1 / workspaces.length) * 100)});
+                treeProvider.refresh(workspaces, config);
             }
             
 			if (workspaces.length === 0) {

--- a/src/lib/loadPendingTasks.ts
+++ b/src/lib/loadPendingTasks.ts
@@ -1,26 +1,35 @@
 import * as vscode from 'vscode';
 import { Workspace } from '../models/workspace';
 import { StoryTreeProvider } from '../storyTreeProvider';
+import { Config } from '../models/config';
 
 /**
  * Loads pending tasks for all workspaces and updates the story tree view.
  * Shows a progress notification while fetching tasks and handles any errors.
  * 
+ * For each workspace, it:
+ * 1. Fetches pending stories via the Shortcut API
+ * 2. Updates the tree view to reflect the new stories
+ * 3. Shows a notification if no workspaces are found
+ * 
  * @param {Workspace[]} workspaces - Array of workspaces to fetch pending tasks for
  * @param {StoryTreeProvider} storyTreeProvider - Provider for the story tree view
+ * @param {Config} config - Configuration settings for the extension
  * @returns {Promise<void>} A promise that resolves when all tasks are loaded
- * @throws {Error} If there's an error fetching pending tasks
+ * @throws {Error} If there's an error fetching pending tasks from the API
  */
-export const loadPendingTasks = async (workspaces: Workspace[], storyTreeProvider: StoryTreeProvider) => {
+export const loadPendingTasks = async (workspaces: Workspace[], storyTreeProvider: StoryTreeProvider, config: Config) => {
     try {
 		await vscode.window.withProgress({
 			location: vscode.ProgressLocation.Notification,
-			title: "Fetching Pending tasks...",
+			title: "Fetching Pending tasks. Workspace: ",
 			cancellable: false
 		}, async (progress) => {
 			for (const workspace of workspaces) {
+				progress.report({message: `${workspace.name}` });
 				await workspace.getPendingStories();
-				storyTreeProvider.refresh(workspaces);
+				progress.report({ increment: ((1 / workspaces.length) * 100)});
+				storyTreeProvider.refresh(workspaces, config);
 			}
 
 			if (workspaces.length === 0) {

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+
+/**
+ * Configuration class that manages extension settings.
+ * Handles loading and storing configuration values from VS Code's workspace settings.
+ */
+export class Config {
+	/** API tokens for authenticating with Shortcut workspaces */
+	apiTokens: object | undefined;
+	/** Whether to hide workspaces that have no stories/tasks */
+	hideEmptyWorkspaces: boolean | undefined;
+
+	/**
+	 * Creates a new Config instance.
+	 * Loads settings from the provided VS Code workspace configuration.
+	 * 
+	 * @param {vscode.WorkspaceConfiguration} [config] - The VS Code workspace configuration object
+	 */
+	constructor(config?: vscode.WorkspaceConfiguration) {   
+		this.apiTokens = config?.get<object[]>('apiTokens');
+		this.hideEmptyWorkspaces = config?.get<boolean>('hideEmptyWorkspaces');
+	}
+}

--- a/src/storyTreeProvider.ts
+++ b/src/storyTreeProvider.ts
@@ -2,11 +2,18 @@ import * as vscode from 'vscode';
 import { Story } from './models/story';
 import { Workspace } from './models/workspace';
 import removeMarkdown from "markdown-to-text";
+import { Config } from './models/config';
 
 /**
- * Tree data provider for displaying Shortcut stories and their tasks in a VS Code tree view.
+ * Tree data provider for displaying pending Shortcut stories and their tasks.
  * Implements the VS Code TreeDataProvider interface to create a hierarchical view of:
  * Workspace -> Stories -> Tasks
+ * 
+ * The tree shows pending stories and their tasks, grouped by workspace.
+ * Each workspace displays the number of pending stories in parentheses.
+ * Empty workspaces can be optionally hidden via configuration.
+ * Stories show their ID and can be expanded to show tasks.
+ * Tasks display their completion status with a checkbox icon.
  */
 export class StoryTreeProvider implements vscode.TreeDataProvider<TreeItem> {
     /** Event emitter for notifying VS Code when the tree data changes */
@@ -16,20 +23,28 @@ export class StoryTreeProvider implements vscode.TreeDataProvider<TreeItem> {
 
     /** Array of workspaces containing stories and tasks */
     private workspaces: Workspace[] = [];
+    /** Configuration settings for the tree view */
+    private config: Config = new Config();
 
     constructor() {}
 
     /**
-     * Refreshes the tree view with updated workspace data.
+     * Refreshes the tree view with updated workspace data and configuration.
+     * Triggers a re-render of the entire tree.
+     * 
      * @param {Workspace[]} workspaces - Array of workspaces to display
+     * @param {Config} config - Updated configuration settings
      */
-    refresh(workspaces: Workspace[]): void {
+    refresh(workspaces: Workspace[], config: Config): void {
         this.workspaces = workspaces;
+        this.config = config;
         this._onDidChangeTreeData.fire();
     }
 
     /**
      * Gets the tree item for an element.
+     * Required by VS Code's TreeDataProvider interface.
+     * 
      * @param {TreeItem} element - The element to get the tree item for
      * @returns {vscode.TreeItem} The tree item for the element
      */
@@ -39,20 +54,33 @@ export class StoryTreeProvider implements vscode.TreeDataProvider<TreeItem> {
 
     /**
      * Gets the children of a tree item.
+     * Handles the hierarchical structure of the tree:
+     * - Root level shows workspaces with pending story counts
+     * - Workspaces contain stories with their IDs
+     * - Stories contain tasks with completion status
+     * 
+     * Empty workspaces can be filtered out based on configuration.
+     * 
      * @param {TreeItem} [element] - The parent element to get children for
      * @returns {Thenable<TreeItem[]>} Promise resolving to array of child tree items
      */
     getChildren(element?: TreeItem): Thenable<TreeItem[]> {
         if (!element) {
             // Root level - return stories
+            let displayedWorkspaces = this.workspaces.map(workspace => new WorkspaceTreeItem(
+                `${workspace.name} (${workspace.pendingStories.length})`,
+                workspace.pendingStories.length > 0 ? 
+                    vscode.TreeItemCollapsibleState.Collapsed : 
+                    vscode.TreeItemCollapsibleState.None,
+                workspace
+            ));
+
+            if (this.config.hideEmptyWorkspaces) {
+                displayedWorkspaces = displayedWorkspaces.filter(workspace => workspace.workspace.pendingStories.length > 0);
+            }
+
             return Promise.resolve(
-                this.workspaces.map(workspace => new WorkspaceTreeItem(
-                    `${workspace.name} (${workspace.pendingStories.length})`,
-                    workspace.pendingStories.length > 0 ? 
-                        vscode.TreeItemCollapsibleState.Collapsed : 
-                        vscode.TreeItemCollapsibleState.None,
-                    workspace
-                ))
+                displayedWorkspaces
             );
         } else if (element instanceof WorkspaceTreeItem) {
             // Story level - return tasks
@@ -85,11 +113,14 @@ export class StoryTreeProvider implements vscode.TreeDataProvider<TreeItem> {
 
 /**
  * Base tree item class that all other tree items extend from.
+ * Provides common functionality for tree items in the view.
+ * 
  * @extends vscode.TreeItem
  */
 class TreeItem extends vscode.TreeItem {
     /**
      * Creates a new TreeItem instance.
+     * 
      * @param {string} label - The display text for the tree item
      * @param {vscode.TreeItemCollapsibleState} collapsibleState - Whether and how the tree item can be expanded
      */
@@ -103,11 +134,15 @@ class TreeItem extends vscode.TreeItem {
 
 /**
  * Tree item representing a Shortcut workspace.
+ * The top level of the hierarchy that contains stories.
+ * Displays the total number of pending stories in parentheses.
+ * 
  * @extends TreeItem
  */
 class WorkspaceTreeItem extends TreeItem {
     /**
      * Creates a new WorkspaceTreeItem instance.
+     * 
      * @param {string} label - The display text for the workspace
      * @param {vscode.TreeItemCollapsibleState} collapsibleState - Whether and how the workspace can be expanded
      * @param {Workspace} workspace - The workspace this tree item represents
@@ -123,11 +158,16 @@ class WorkspaceTreeItem extends TreeItem {
 
 /**
  * Tree item representing a Shortcut story.
+ * The second level of the hierarchy that contains tasks.
+ * Displays the story name and ID, with a book icon.
+ * Provides context menu actions via contextValue.
+ * 
  * @extends TreeItem
  */
 class StoryTreeItem extends TreeItem {
     /**
      * Creates a new StoryTreeItem instance.
+     * 
      * @param {string} label - The display text for the story
      * @param {number} storyId - The unique identifier of the story
      * @param {vscode.TreeItemCollapsibleState} collapsibleState - Whether and how the story can be expanded
@@ -151,11 +191,16 @@ class StoryTreeItem extends TreeItem {
 
 /**
  * Tree item representing a task within a Shortcut story.
+ * The leaf level of the hierarchy.
+ * Displays the task description and completion status with a checkbox icon.
+ * Provides context menu actions via contextValue.
+ * 
  * @extends TreeItem
  */
 class TaskTreeItem extends TreeItem {
     /**
      * Creates a new TaskTreeItem instance.
+     * 
      * @param {string} label - The display text for the task
      * @param {boolean} isComplete - Whether the task is marked as complete
      * @param {number} taskId - The unique identifier of the task


### PR DESCRIPTION
Closes #11 

- Add a new setting to hide empty workspaces, false by default
- Do not show empty workspaces, workflows or states when the setting is enabled
- Better progress bar notifications